### PR TITLE
feature/VTA-621 - Vehicle History Page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -76,7 +76,7 @@ const routes: Routes = [
     path: PAGE_NAMES.VEHICLE_HISTORY_PAGE,
     loadChildren: () =>
       import('./pages/vehicle/vehicle-history/vehicle-history.module')
-        .then( m => m.VehicleHistoryPageModule)
+        .then( m => m.VehicleHistoryModule)
   }
 ];
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -72,6 +72,12 @@ const routes: Routes = [
     loadChildren: () => import('./pages/testing/test-creation/test-cancel/test-cancel.module')
         .then( m => m.TestCancelModule)
   },
+  {
+    path: PAGE_NAMES.VEHICLE_HISTORY_PAGE,
+    loadChildren: () =>
+      import('./pages/vehicle/vehicle-history/vehicle-history.module')
+        .then( m => m.VehicleHistoryPageModule)
+  }
 ];
 
 @NgModule({

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.module.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.module.ts
@@ -7,7 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { CommonModule } from '@angular/common';
 import { VehicleDetailsPageRoutingModule } from '@app/pages/vehicle/vehicle-details/vehicle-details-routing.module';
 import { FormatVrmPipe } from '@pipes/format-vrm/format-vrm.pipe';
-import {VehicleService} from "@providers/vehicle/vehicle.service";
+import { VehicleService } from '@providers/vehicle/vehicle.service';
 
 @NgModule({
   declarations: [

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.module.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.module.ts
@@ -7,6 +7,7 @@ import { IonicModule } from '@ionic/angular';
 import { CommonModule } from '@angular/common';
 import { VehicleDetailsPageRoutingModule } from '@app/pages/vehicle/vehicle-details/vehicle-details-routing.module';
 import { FormatVrmPipe } from '@pipes/format-vrm/format-vrm.pipe';
+import {VehicleService} from "@providers/vehicle/vehicle.service";
 
 @NgModule({
   declarations: [
@@ -22,6 +23,7 @@ import { FormatVrmPipe } from '@pipes/format-vrm/format-vrm.pipe';
     CommonFunctionsService,
     TestService,
     FormatVrmPipe,
+    VehicleService,
   ]
 })
 export class VehicleDetailsModule {}

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.spec.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.spec.ts
@@ -13,7 +13,7 @@ import { TestTypeArrayDataMock } from '@assets/data-mocks/test-type-array-data.m
 import {
   ANALYTICS_SCREEN_NAMES,
   APP_STRINGS, PAGE_NAMES,
-  TECH_RECORD_STATUS, TESTER_ROLES
+  TECH_RECORD_STATUS,
 } from '@app/app.enums';
 import { By } from '@angular/platform-browser';
 import { VehicleModel } from '@models/vehicle/vehicle.model';
@@ -24,15 +24,17 @@ import { AnalyticsService } from '@providers/global';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 import { FormatVrmPipe } from '@pipes/format-vrm/format-vrm.pipe';
+import {VehicleService} from '@providers/vehicle/vehicle.service';
+import {VehicleServiceMock} from '@test-config/services-mocks/vehicle-service.mock';
+import {LogsProvider} from '@store/logs/logs.service';
+import {AuthenticationService} from '@providers/auth';
+import {AuthenticationServiceMock} from '@test-config/services-mocks/authentication-service.mock';
 import { VisitService } from '@providers/visit/visit.service';
 import { VisitServiceMock } from '@test-config/services-mocks/visit-service.mock';
 import { TestService } from '@providers/test/test.service';
 import { TestServiceMock } from '@test-config/services-mocks/test-service.mock';
 import { TestModel } from '@models/tests/test.model';
 import { TestCreatePage } from '@app/pages/testing/test-creation/test-create/test-create';
-import { AuthenticationService } from '@providers/auth';
-import { AuthenticationServiceMock } from '@test-config/services-mocks/authentication-service.mock';
-import { TokenInfo } from '@providers/auth/authentication/auth-model';
 import { VehicleLookupPage } from '@app/pages/vehicle/vehicle-lookup/vehicle-lookup';
 import { TestStationDataMock } from '@assets/data-mocks/reference-data-mocks/test-station-data.mock';
 
@@ -49,6 +51,7 @@ describe('Component: VehicleDetailsPage', () => {
   let visitService: VisitService;
   let authService: AuthenticationService;
   let navController: NavController;
+  let logProviderSpy: any;
 
   const VEHICLE: VehicleModel = VehicleDataMock.VehicleData;
   const TEST = TestTypeArrayDataMock.TestTypeArrayData[0];
@@ -56,6 +59,9 @@ describe('Component: VehicleDetailsPage', () => {
 
   beforeEach(() => {
     callNumberSpy = jasmine.createSpyObj('CallNumber', ['callNumber']);
+    logProviderSpy = jasmine.createSpyObj('LogsProvider', {
+      dispatchLog: () => true
+    });
 
     analyticsServiceSpy = jasmine.createSpyObj('AnalyticsService', [
       'logEvent',
@@ -85,10 +91,12 @@ describe('Component: VehicleDetailsPage', () => {
         { provide: AnalyticsService, useValue: analyticsServiceSpy },
         { provide: AppService, useClass: AppServiceMock },
         { provide: ModalController, useFactory: () => ModalControllerMock.instance() },
+        { provide: VehicleService, useClass: VehicleServiceMock },
+        { provide: LogsProvider, useValue: logProviderSpy },
+        { provide: AuthenticationService, useClass: AuthenticationServiceMock },
         { provide: AppService, useClass: AppServiceMock },
         { provide: VisitService, useClass: VisitServiceMock },
         { provide: TestService, useClass: TestServiceMock },
-        { provide: AuthenticationService, useClass: AuthenticationServiceMock },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.spec.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.spec.ts
@@ -1,10 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { VehicleDetailsPage } from './vehicle-details';
 import {
-  AlertController, ModalController, NavController,
+  NavController,
+  AlertController, LoadingController, ModalController,
 } from '@ionic/angular';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { AlertControllerMock, ModalControllerMock } from 'ionic-mocks';
+import { AlertControllerMock, LoadingControllerMock, ModalControllerMock } from 'ionic-mocks';
 import { StorageService } from '@providers/natives/storage.service';
 import { StorageServiceMock } from '@test-config/services-mocks/storage-service.mock';
 import { CommonFunctionsService } from '@providers/utils/common-functions';
@@ -55,6 +56,7 @@ describe('Component: VehicleDetailsPage', () => {
   let navController: NavController;
   let logProviderSpy: any;
   let vehicleService: VehicleService;
+  let loadingController: LoadingController;
 
   const VEHICLE: VehicleModel = VehicleDataMock.VehicleData;
   const TEST = TestTypeArrayDataMock.TestTypeArrayData[0];
@@ -101,6 +103,7 @@ describe('Component: VehicleDetailsPage', () => {
         { provide: AppService, useClass: AppServiceMock },
         { provide: VisitService, useClass: VisitServiceMock },
         { provide: TestService, useClass: TestServiceMock },
+        { provide: LoadingController, useFactory: () => LoadingControllerMock.instance() },
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });
@@ -116,6 +119,7 @@ describe('Component: VehicleDetailsPage', () => {
     testReportService = TestBed.inject(TestService);
     visitService = TestBed.inject(VisitService);
     vehicleService = TestBed.inject(VehicleService);
+    loadingController = TestBed.inject(LoadingController);
     authService = TestBed.inject(AuthenticationService);
     navController = TestBed.inject(NavController);
     spyOn(router, 'getCurrentNavigation').and.returnValue(

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.spec.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.spec.ts
@@ -257,7 +257,7 @@ describe('Component: VehicleDetailsPage', () => {
 
       await component.goToVehicleTestResultsHistory();
 
-      expect(router.navigate).toHaveBeenCalledWith(
+      expect(await router.navigate).toHaveBeenCalledWith(
         [PAGE_NAMES.VEHICLE_HISTORY_PAGE],
         {
           state: {

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.spec.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.spec.ts
@@ -263,6 +263,7 @@ describe('Component: VehicleDetailsPage', () => {
           state: {
             vehicleData: component.vehicleData,
             testResultsHistory: TEST_HISTORY_DATA,
+            previousPageName: PAGE_NAMES.VEHICLE_HISTORY_PAGE,
           }
         }
       );

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.spec.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.spec.ts
@@ -13,7 +13,7 @@ import { TestTypeArrayDataMock } from '@assets/data-mocks/test-type-array-data.m
 import {
   ANALYTICS_SCREEN_NAMES,
   APP_STRINGS, PAGE_NAMES,
-  TECH_RECORD_STATUS,
+  TECH_RECORD_STATUS
 } from '@app/app.enums';
 import { By } from '@angular/platform-browser';
 import { VehicleModel } from '@models/vehicle/vehicle.model';
@@ -34,6 +34,8 @@ import { VisitServiceMock } from '@test-config/services-mocks/visit-service.mock
 import { TestService } from '@providers/test/test.service';
 import { TestServiceMock } from '@test-config/services-mocks/test-service.mock';
 import { TestModel } from '@models/tests/test.model';
+import {of} from 'rxjs';
+import {TestResultsHistoryDataMock} from '@assets/data-mocks/test-results-history-data.mock';
 import { TestCreatePage } from '@app/pages/testing/test-creation/test-create/test-create';
 import { VehicleLookupPage } from '@app/pages/vehicle/vehicle-lookup/vehicle-lookup';
 import { TestStationDataMock } from '@assets/data-mocks/reference-data-mocks/test-station-data.mock';
@@ -52,10 +54,12 @@ describe('Component: VehicleDetailsPage', () => {
   let authService: AuthenticationService;
   let navController: NavController;
   let logProviderSpy: any;
+  let vehicleService: VehicleService;
 
   const VEHICLE: VehicleModel = VehicleDataMock.VehicleData;
   const TEST = TestTypeArrayDataMock.TestTypeArrayData[0];
   const TEST_STATION = TestStationDataMock.TestStationData[0];
+  const TEST_HISTORY_DATA = TestResultsHistoryDataMock.TestResultHistoryData;
 
   beforeEach(() => {
     callNumberSpy = jasmine.createSpyObj('CallNumber', ['callNumber']);
@@ -111,6 +115,7 @@ describe('Component: VehicleDetailsPage', () => {
     router = TestBed.inject(Router);
     testReportService = TestBed.inject(TestService);
     visitService = TestBed.inject(VisitService);
+    vehicleService = TestBed.inject(VehicleService);
     authService = TestBed.inject(AuthenticationService);
     navController = TestBed.inject(NavController);
     spyOn(router, 'getCurrentNavigation').and.returnValue(
@@ -236,6 +241,27 @@ describe('Component: VehicleDetailsPage', () => {
     fixture.whenStable().then(() => {
       const title = fixture.debugElement.query(By.css('ion-toolbar .ion-padding-start'));
       expect(title.nativeElement.innerText).toBe(APP_STRINGS.PROVISIONAL_LABEL_TEXT);
+    });
+  });
+
+  describe('goToTestVehicleTestResultsHistory', () => {
+    it('should pass data to router.navigate if vehicle history data is returned', async () => {
+      spyOn(vehicleService, 'getTestResultsHistory').and.returnValue(of(
+        TEST_HISTORY_DATA
+      ));
+      spyOn(router, 'navigate');
+
+      await component.goToVehicleTestResultsHistory();
+
+      expect(router.navigate).toHaveBeenCalledWith(
+        [PAGE_NAMES.VEHICLE_HISTORY_PAGE],
+        {
+          state: {
+            vehicleData: component.vehicleData,
+            testResultsHistory: TEST_HISTORY_DATA,
+          }
+        }
+      );
     });
   });
 

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
@@ -76,11 +76,15 @@ export class VehicleDetailsPage implements OnInit {
   }
 
   ngOnInit(): void {
+    // this mess will be fixed with the ngrx implementation
     this.route.params.subscribe(val => {
-      this.previousPageName = this.router.getCurrentNavigation().extras.state.previousPageName;
-      this.vehicleData = this.router.getCurrentNavigation().extras.state.vehicle;
-      this.testData = this.router.getCurrentNavigation().extras.state.test;
-      this.testStation = this.router.getCurrentNavigation().extras.state.testStation;
+      try {
+        this.previousPageName = this.router.getCurrentNavigation().extras.state.previousPageName;
+        this.vehicleData = this.router.getCurrentNavigation().extras.state.vehicle;
+        this.testData = this.router.getCurrentNavigation().extras.state.test;
+        this.testStation = this.router.getCurrentNavigation().extras.state.testStation;
+      } catch {
+      }
       this.backButtonText = this.getBackButtonText();
     });
   }

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
@@ -122,6 +122,7 @@ export class VehicleDetailsPage implements OnInit {
       message: 'Loading...'
     });
     await loadingSpinner.present();
+
     this.vehicleService
       .getTestResultsHistory(this.vehicleData.systemNumber)
       .subscribe(

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
@@ -118,6 +118,8 @@ export class VehicleDetailsPage implements OnInit {
             vehicleData: this.vehicleData,
             testResultsHistory: data ? data : [],
           }
+        }).catch((error) => {
+          console.log(error);
         });
       });
   }

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
@@ -133,6 +133,7 @@ export class VehicleDetailsPage implements OnInit {
               state: {
                 vehicleData: this.vehicleData,
                 testResultsHistory: data,
+                previousPageName: PAGE_NAMES.VEHICLE_HISTORY_PAGE,
               }
             });
           },
@@ -154,6 +155,7 @@ export class VehicleDetailsPage implements OnInit {
               state: {
                 vehicleData: this.vehicleData,
                 testResultsHistory: [],
+                previousPageName: PAGE_NAMES.VEHICLE_HISTORY_PAGE,
               }
             });
           },

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
@@ -66,7 +66,6 @@ export class VehicleDetailsPage implements OnInit {
     public vehicleService: VehicleService,
     public logProvider: LogsProvider,
     private authenticationService: AuthenticationService,
-    public formatVrmPipe: FormatVrmPipe,
     private visitService: VisitService,
     private testReportService: TestService,
     private route: ActivatedRoute,

--- a/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
+++ b/src/app/pages/vehicle/vehicle-details/vehicle-details.ts
@@ -64,14 +64,14 @@ export class VehicleDetailsPage implements OnInit {
     public appService: AppService,
     private router: Router,
     public modalCtrl: ModalController,
+    public formatVrmPipe: FormatVrmPipe,
     public vehicleService: VehicleService,
     public logProvider: LogsProvider,
+    private authService: AuthenticationService,
     private visitService: VisitService,
     private testReportService: TestService,
     private route: ActivatedRoute,
-    private authService: AuthenticationService,
     public loadingController: LoadingController,
-    public formatVrmPipe: FormatVrmPipe,
   ) {
   }
 

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history-routing.module.ts
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history-routing.module.ts
@@ -1,12 +1,11 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
-
-import {VehicleDetailsPage} from '@app/pages/vehicle/vehicle-details/vehicle-details';
+import {VehicleHistoryPage} from '@app/pages/vehicle/vehicle-history/vehicle-history';
 
 const routes: Routes = [
   {
     path: '',
-    component: VehicleDetailsPage
+    component: VehicleHistoryPage
   }
 ];
 
@@ -14,4 +13,4 @@ const routes: Routes = [
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule],
 })
-export class VehicleDetailsPageRoutingModule {}
+export class VehicleHistoryPageRoutingModule {}

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.html
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.html
@@ -9,7 +9,7 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="ion-no-padding">
+<ion-content class="ion-no-padding content-background-color-grey">
   <div class="vehicle-header-vrm-number ion-text-capitalize ion-text-center">
     <ng-container *ngIf="isVehicleOfType(vehicleData,VEHICLE_TYPE.TRL); else isVehicle"
     >{{ vehicleData.trailerId }}</ng-container
@@ -19,14 +19,14 @@
 
   <ion-list class="tests-list" *ngIf="testResultHistory.length">
     <ng-container *ngFor="let testType of testTypeArray">
-      <ion-item (click)="showTestDetails(testType.testIndex, testType.testTypeIndex)">
+      <ion-item (click)="showTestDetails(testType.testIndex, testType.testTypeIndex)" class="ion-no-padding">
         <ion-grid>
           <ion-row class="ion-padding-start ion-justify-content-between">
-            <ion-col size="auto">
+            <ion-col>
               <p text-wrap>{{ testType.name }}</p>
             </ion-col>
 
-            <ion-col size="auto" class="ion-text-right">
+            <ion-col class="ion-text-right">
               <ion-text
                 *ngIf="!haveProhibition(testType)"
                 class="test-result ion-text-capitalize"
@@ -44,18 +44,18 @@
           </ion-row>
 
           <ion-row class="ion-justify-content-between ion-padding-start">
-            <ion-col size="auto">
+            <ion-col>
               <p>Test date</p>
             </ion-col>
-            <ion-col size="auto" class="ion-text-right">
+            <ion-col class="ion-text-right">
               <p>{{ testType.testTypeStartTimestamp | date:'dd MMM yyyy' }}</p>
             </ion-col>
           </ion-row>
           <ion-row class="ion-justify-content-between ion-padding-start" *ngIf="testType.testExpiryDate">
-            <ion-col size="auto">
+            <ion-col >
               <p>Expiry date</p>
             </ion-col>
-            <ion-col size="auto" class="ion-text-right">
+            <ion-col class="ion-text-right">
               <p>{{ testType.testExpiryDate | date:'dd MMM yyyy' }}</p>
             </ion-col>
           </ion-row>

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.html
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.html
@@ -1,0 +1,70 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button [text]="previousPageName"></ion-back-button>
+    </ion-buttons>
+    <ion-title class="ion-margin-start">
+      <span>Test history</span>
+    </ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-no-padding">
+  <div class="vehicle-header-vrm-number ion-text-capitalize ion-text-center">
+    <ng-container *ngIf="isVehicleOfType(vehicleData,VEHICLE_TYPE.TRL); else isVehicle"
+    >{{ vehicleData.trailerId }}</ng-container
+    >
+    <ng-template #isVehicle>{{ vehicleData.vrm | formatVrm }}</ng-template>
+  </div>
+
+  <ion-list class="tests-list" *ngIf="testResultHistory.length">
+    <ng-container *ngFor="let testType of testTypeArray">
+      <ion-item (click)="showTestDetails(testType.testIndex, testType.testTypeIndex)">
+        <ion-grid>
+          <ion-row class="ion-padding-start ion-justify-content-between">
+            <ion-col size="auto">
+              <p text-wrap>{{ testType.name }}</p>
+            </ion-col>
+
+            <ion-col size="auto" class="ion-text-right">
+              <ion-text
+                *ngIf="!haveProhibition(testType)"
+                class="test-result ion-text-capitalize"
+                [color]="commonFunc.getTestResultColor(testType.testResult)"
+              >
+                {{ testType.testResult }}
+              </ion-text>
+              <ion-text
+                *ngIf="haveProhibition(testType)"
+                class="test-result ion-text-capitalize ion-color-dark"
+              >
+                PROHIBITION
+              </ion-text>
+            </ion-col>
+          </ion-row>
+
+          <ion-row class="ion-justify-content-between ion-padding-start">
+            <ion-col size="auto">
+              <p>Test date</p>
+            </ion-col>
+            <ion-col size="auto" class="ion-text-right">
+              <p>{{ testType.testTypeStartTimestamp | date:'dd MMM yyyy' }}</p>
+            </ion-col>
+          </ion-row>
+          <ion-row class="ion-justify-content-between ion-padding-start" *ngIf="testType.testExpiryDate">
+            <ion-col size="auto">
+              <p>Expiry date</p>
+            </ion-col>
+            <ion-col size="auto" class="ion-text-right">
+              <p>{{ testType.testExpiryDate | date:'dd MMM yyyy' }}</p>
+            </ion-col>
+          </ion-row>
+        </ion-grid>
+      </ion-item>
+    </ng-container>
+  </ion-list>
+
+  <div *ngIf="!testResultHistory.length" class="no-result">
+    <h3>{{ noHistory }}</h3>
+  </div>
+</ion-content>

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.module.ts
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { VehicleHistoryPage } from './vehicle-history';
+import { CommonFunctionsService } from '@providers/utils/common-functions';
+import { PipesModule } from '@pipes/pipes.module';
+import { TestTypeService } from '@providers/test-type/test-type.service';
+import {VehicleHistoryPageRoutingModule} from "@app/pages/vehicle/vehicle-history/vehicle-history-routing.module";
+import {IonicModule} from "@ionic/angular";
+import {CommonModule} from "@angular/common";
+
+@NgModule({
+  declarations: [VehicleHistoryPage],
+  imports: [
+    PipesModule,
+    VehicleHistoryPageRoutingModule,
+    IonicModule,
+    CommonModule,
+  ],
+  providers: [CommonFunctionsService, TestTypeService]
+})
+export class VehicleHistoryPageModule {}

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.module.ts
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.module.ts
@@ -17,4 +17,4 @@ import {CommonModule} from "@angular/common";
   ],
   providers: [CommonFunctionsService, TestTypeService]
 })
-export class VehicleHistoryPageModule {}
+export class VehicleHistoryModule {}

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.scss
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.scss
@@ -1,0 +1,47 @@
+:host {
+  ion-content {
+    .scroll-content {
+      background: var(--color-grey-3);
+    }
+  }
+
+  .tests-list {
+    margin-top: 30px;
+
+      align-items: flex-start;
+      min-height: 105px;
+
+      p {
+        font-size: var(--font-size-medium);
+      }
+
+      ion-row {
+        ion-col {
+          padding: 2px 0;
+        }
+
+        &:first-of-type ion-col {
+          font-weight: var(--font-weight-semi-bold);
+        }
+
+        ion-col:first-of-type {
+          p {
+            color: var(--dark);
+          }
+        }
+      }
+  }
+
+  .no-result {
+    margin: auto;
+    width: 250px;
+    max-height: 50%;
+    text-align: center;
+    h3 {
+      color: var(--color-grey-1);
+      font-size: var(--font-size-medium);
+      font-weight: var(--font-weight-semi-bold);
+      font-family: var(--sf-pro-font-family);
+    }
+  }
+}

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.scss
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.scss
@@ -7,13 +7,19 @@
 
   .tests-list {
     margin-top: 30px;
-
+    //.item-ios {
       align-items: flex-start;
       min-height: 105px;
 
       p {
         font-size: var(--font-size-medium);
+        margin: 0;
       }
+
+    ion-grid {
+      margin-top: 10px;
+      margin-bottom: 10px;
+    }
 
       ion-row {
         ion-col {
@@ -30,6 +36,7 @@
           }
         }
       }
+    //}
   }
 
   .no-result {

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.scss
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.scss
@@ -7,7 +7,6 @@
 
   .tests-list {
     margin-top: 30px;
-    //.item-ios {
       align-items: flex-start;
       min-height: 105px;
 
@@ -36,7 +35,6 @@
           }
         }
       }
-    //}
   }
 
   .no-result {

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.spec.ts
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.spec.ts
@@ -92,8 +92,8 @@ describe('Component: VehicleHistoryPage', () => {
     done();
   });
 
-  it('should test ionViewDidEnterLogic', () => {
-    comp.ionViewDidEnter();
+  it('should test ionViewDidEnterLogic', async () => {
+    await comp.ionViewDidEnter();
 
     expect(analyticsService.setCurrentPage).toHaveBeenCalledWith(
       ANALYTICS_SCREEN_NAMES.VEHICLE_TEST_HISTORY

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.spec.ts
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.spec.ts
@@ -95,7 +95,7 @@ describe('Component: VehicleHistoryPage', () => {
   it('should test ionViewDidEnterLogic', async () => {
     await comp.ionViewDidEnter();
 
-    expect(analyticsService.setCurrentPage).toHaveBeenCalledWith(
+    expect(await analyticsService.setCurrentPage).toHaveBeenCalledWith(
       ANALYTICS_SCREEN_NAMES.VEHICLE_TEST_HISTORY
     );
   });

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.spec.ts
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.spec.ts
@@ -1,0 +1,267 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NavController, NavParams } from '@ionic/angular';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NavParamsMock } from '@test-config/ionic-mocks/nav-params.mock';
+import { CommonFunctionsService } from '@providers/utils/common-functions';
+import { VehicleDataMock } from '@assets/data-mocks/vehicle-data.mock';
+import { PipesModule } from '@pipes/pipes.module';
+import { TestResultsHistoryDataMock } from '@assets/data-mocks/test-results-history-data.mock';
+import { TestTypeArrayDataMock } from '@assets/data-mocks/test-type-array-data.mock';
+import {
+  ANALYTICS_SCREEN_NAMES, PAGE_NAMES,
+  TECH_RECORD_STATUS,
+  VEHICLE_TYPE
+} from '@app/app.enums';
+import { VehicleHistoryPage } from './vehicle-history';
+import { VehicleModel } from '@models/vehicle/vehicle.model';
+import { AnalyticsService } from '@providers/global';
+import { TestTypeService } from '@providers/test-type/test-type.service';
+import {RouterTestingModule} from '@angular/router/testing';
+import {Router} from '@angular/router';
+
+describe('Component: VehicleHistoryPage', () => {
+  let comp: VehicleHistoryPage;
+  let fixture: ComponentFixture<VehicleHistoryPage>;
+  let navCtrl: NavController;
+  let commonFunctionsService: any;
+  let analyticsService: AnalyticsService;
+  let analyticsServiceSpy: any;
+  let testTypeService: TestTypeService;
+  let testTypeServiceSpy: any;
+  let router: any;
+
+  const testResultsHistory: any = TestResultsHistoryDataMock.TestResultHistoryData;
+  const vehicleData: VehicleModel = VehicleDataMock.VehicleData;
+  const testTypeArray = TestTypeArrayDataMock.TestTypeArrayData;
+
+  beforeEach(async(() => {
+    analyticsServiceSpy = jasmine.createSpyObj('AnalyticsService', ['setCurrentPage']);
+    testTypeServiceSpy = jasmine.createSpyObj('TestTypeService', ['fixDateFormatting']);
+
+    TestBed.configureTestingModule({
+      declarations: [VehicleHistoryPage],
+      imports: [
+        RouterTestingModule.withRoutes([]),
+        PipesModule,
+      ],
+      providers: [
+        NavController,
+        CommonFunctionsService,
+        { provide: AnalyticsService, useValue: analyticsServiceSpy },
+        { provide: TestTypeService, useValue: testTypeServiceSpy }
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    });
+
+    fixture = TestBed.createComponent(VehicleHistoryPage);
+    comp = fixture.componentInstance;
+    navCtrl = TestBed.inject(NavController);
+    analyticsService = TestBed.inject(AnalyticsService);
+    testTypeService = TestBed.inject(TestTypeService);
+    commonFunctionsService = TestBed.inject(CommonFunctionsService);
+    router = TestBed.inject(Router);
+    spyOn(router, 'getCurrentNavigation').and.returnValue(
+      { extras:
+          {
+            state: {
+              previousPage: PAGE_NAMES.VISIT_TIMELINE_PAGE,
+              vehicleData,
+              testResultsHistory,
+            }
+          }
+      } as any
+    );
+  }));
+
+  beforeEach(() => {
+    comp.vehicleData = vehicleData;
+    comp.testResultHistory = testResultsHistory;
+    comp.testResultHistoryClone = comp.testResultHistory;
+    comp.testTypeArray = testTypeArray;
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    comp = null;
+  });
+
+  it('should create the component', (done) => {
+    expect(fixture).toBeTruthy();
+    expect(comp).toBeTruthy();
+    done();
+  });
+
+  it('should test ionViewDidEnterLogic', () => {
+    comp.ionViewDidEnter();
+
+    expect(analyticsService.setCurrentPage).toHaveBeenCalledWith(
+      ANALYTICS_SCREEN_NAMES.VEHICLE_TEST_HISTORY
+    );
+  });
+
+  it('should create an array called testTypeArray if testHistory exists', () => {
+    comp.testTypeArray = [];
+    comp.createTestTypeArray();
+    expect(comp.testTypeArray.length).toBeTruthy();
+  });
+
+  it('should not create an array called testTypeArray if testHistory does not exists', () => {
+    comp.testTypeArray = [];
+    comp.testResultHistory = [];
+    comp.createTestTypeArray();
+    expect(comp.testTypeArray.length).toBeFalsy();
+  });
+
+  it('should not create an array called testTypeArray if testStatus in not submitted', () => {
+    comp.testTypeArray = [];
+    comp.testResultHistory[0].testStatus = 'cancelled';
+    comp.testResultHistory[1].testStatus = 'cancelled';
+    comp.createTestTypeArray();
+    expect(comp.testTypeArray.length).toBeFalsy();
+  });
+
+  it('should check if any defect have an prohibition issued and returns true, otherwise return false', () => {
+    const testType = {
+      prohibitionIssued: false,
+      testCode: 'pms',
+      lastUpdatedAt: '2019-05-23T12:49:21.455Z',
+      testNumber: 'W01B89366',
+      additionalCommentsForAbandon: 'none',
+      numberOfSeatbeltsFitted: 2,
+      testTypeEndTimestamp: '2019-01-14T10:36:33.987Z',
+      reasonForAbandoning: 'none',
+      lastSeatbeltInstallationCheckDate: '2019-01-14',
+      createdAt: '2019-05-23T12:49:21.455Z',
+      testTypeId: '19',
+      testTypeStartTimestamp: '2019-01-14T10:36:33.987Z',
+      certificateNumber: '12334',
+      testTypeName: 'Annual test',
+      seatbeltInstallationCheckDate: true,
+      additionalNotesRecorded: 'VEHICLE FRONT ROW SECOND SEAT HAS MISSING SEATBELT',
+      defects: [
+        {
+          deficiencyCategory: 'major',
+          deficiencyText: 'missing.',
+          prs: false,
+          additionalInformation: {
+            location: {
+              axleNumber: null,
+              horizontal: null,
+              vertical: 'upper',
+              longitudinal: null,
+              rowNumber: 1,
+              lateral: 'centre',
+              seatNumber: 2
+            },
+            notes: 'seatbelt missing'
+          },
+          itemNumber: 1,
+          deficiencyRef: '3.1.a',
+          stdForProhibition: false,
+          prohibitionIssued: false,
+          deficiencySubId: null,
+          imDescription: 'Seat Belts & Supplementary Restraint Systems',
+          deficiencyId: 'a',
+          itemDescription: 'Obligatory Seat Belt:',
+          imNumber: 3
+        },
+        {
+          deficiencyCategory: 'major',
+          deficiencyText: 'missing.',
+          prs: false,
+          additionalInformation: {
+            location: {
+              axleNumber: null,
+              horizontal: null,
+              vertical: 'upper',
+              longitudinal: null,
+              rowNumber: 1,
+              lateral: 'centre',
+              seatNumber: 2
+            },
+            notes: 'seatbelt missing'
+          },
+          itemNumber: 1,
+          deficiencyRef: '3.1.a',
+          stdForProhibition: true,
+          prohibitionIssued: true,
+          deficiencySubId: null,
+          imDescription: 'Seat Belts & Supplementary Restraint Systems',
+          deficiencyId: 'a',
+          itemDescription: 'Obligatory Seat Belt:',
+          imNumber: 3
+        },
+        {
+          deficiencyCategory: 'major',
+          deficiencyText: 'missing.',
+          prs: false,
+          additionalInformation: {
+            location: {
+              axleNumber: null,
+              horizontal: null,
+              vertical: 'upper',
+              longitudinal: null,
+              rowNumber: 1,
+              lateral: 'centre',
+              seatNumber: 2
+            },
+            notes: 'seatbelt missing'
+          },
+          itemNumber: 1,
+          deficiencyRef: '3.1.a',
+          stdForProhibition: false,
+          prohibitionIssued: false,
+          deficiencySubId: null,
+          imDescription: 'Seat Belts & Supplementary Restraint Systems',
+          deficiencyId: 'a',
+          itemDescription: 'Obligatory Seat Belt:',
+          imNumber: 3
+        }
+      ],
+      name: 'Annual test',
+      testResult: 'fail',
+      testIndex: 52,
+      testTypeIndex: 0
+    };
+    expect(comp.haveProhibition(testType)).toBeTruthy();
+    testType.defects = [];
+    expect(comp.haveProhibition(testType)).toBeFalsy();
+    testType.prohibitionIssued = true;
+    expect(comp.haveProhibition(testType)).toBeTruthy();
+  });
+
+  it('should verify that the vehicle type is one of the specified types', () => {
+    const vehicle = Object.create(VehicleDataMock.VehicleData);
+    expect(comp.isVehicleOfType(vehicle, VEHICLE_TYPE.PSV)).toBeTruthy();
+    expect(
+      comp.isVehicleOfType(vehicle, VEHICLE_TYPE.PSV, VEHICLE_TYPE.TRL, VEHICLE_TYPE.HGV)
+    ).toBeTruthy();
+  });
+
+  it('should verify that the vehicle type is not one of specified types', () => {
+    const vehicle = Object.create(VehicleDataMock.VehicleData);
+    expect(comp.isVehicleOfType(vehicle, VEHICLE_TYPE.TRL)).toBeFalsy();
+    expect(comp.isVehicleOfType(vehicle, VEHICLE_TYPE.TRL, VEHICLE_TYPE.HGV)).toBeFalsy();
+  });
+
+  it('should not display the provisional label if the techRecord is current', () => {
+    comp.vehicleData.techRecord.statusCode = TECH_RECORD_STATUS.CURRENT;
+
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      const title = fixture.debugElement.query(By.css('ion-toolbar ion-title div.toolbar-title'));
+      expect(title).toBeNull();
+    });
+  });
+
+  it('should not display the provisional label even if the techRecord is provisional', () => {
+    comp.vehicleData.techRecord.statusCode = TECH_RECORD_STATUS.PROVISIONAL;
+
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      const title = fixture.debugElement.query(By.css('ion-toolbar ion-title div.toolbar-title'));
+      expect(title).toBeNull();
+    });
+  });
+});

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.ts
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.ts
@@ -36,6 +36,7 @@ export class VehicleHistoryPage implements OnInit {
   ) { }
 
   ngOnInit() {
+    this.previousPageName = this.router.getCurrentNavigation().extras.state.previousPageName;
     this.vehicleData = this.router.getCurrentNavigation().extras.state.vehicleData;
     this.testResultHistory = this.router.getCurrentNavigation().extras.state.testResultsHistory;
     this.testResultHistoryClone = this.commonFunc.cloneObject(this.testResultHistory);

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.ts
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.ts
@@ -1,0 +1,105 @@
+import { Component, OnInit } from '@angular/core';
+import { VehicleModel } from '@models/vehicle/vehicle.model';
+import { CommonFunctionsService } from '@providers/utils/common-functions';
+import {
+  APP_STRINGS,
+  TEST_TYPE_RESULTS,
+  TEST_REPORT_STATUSES,
+  VEHICLE_TYPE,
+  ANALYTICS_SCREEN_NAMES
+} from '@app/app.enums';
+import { TestResultModel } from '@models/tests/test-result.model';
+import { AnalyticsService } from '@providers/global';
+import { TestTypeService } from '@providers/test-type/test-type.service';
+import {Router} from '@angular/router';
+
+@Component({
+  selector: 'page-vehicle-history',
+  templateUrl: 'vehicle-history.html',
+  styleUrls: ['vehicle-history.scss'],
+})
+export class VehicleHistoryPage implements OnInit {
+  VEHICLE_TYPE: typeof VEHICLE_TYPE = VEHICLE_TYPE;
+  vehicleData: VehicleModel;
+  testResultHistory: TestResultModel[];
+  testTypeResults = TEST_TYPE_RESULTS;
+  noHistory: string;
+  testResultHistoryClone: any[] = [];
+  testTypeArray: any[] = [];
+  previousPageName: string;
+
+  constructor(
+    public router: Router,
+    public commonFunc: CommonFunctionsService,
+    private analyticsService: AnalyticsService,
+    public testTypeService: TestTypeService
+  ) { }
+
+  ngOnInit() {
+    this.vehicleData = this.router.getCurrentNavigation().extras.state.vehicleData;
+    this.testResultHistory = this.router.getCurrentNavigation().extras.state.testResultsHistory;
+    this.testResultHistoryClone = this.commonFunc.cloneObject(this.testResultHistory);
+    this.createTestTypeArray();
+    this.commonFunc.orderTestTypeArrayByDate(this.testTypeArray);
+  }
+
+  ionViewWillEnter() {
+    this.noHistory = APP_STRINGS.NO_HISTORY;
+    this.previousPageName = APP_STRINGS.VEHICLE_DETAILS;
+  }
+
+  async ionViewDidEnter(): Promise<void> {
+    await this.analyticsService.setCurrentPage(ANALYTICS_SCREEN_NAMES.VEHICLE_TEST_HISTORY);
+  }
+
+  async showTestDetails(testIndex: number, testTypeIndex: number): Promise<void> {
+    await this.router.navigate(['VehicleHistoryDetailsPage'], {
+      state: {
+        testResultHistory: this.testResultHistory,
+        testIndex,
+        testTypeIndex,
+        vehicleType: this.vehicleData.techRecord.vehicleType
+      }
+    });
+  }
+
+  createTestTypeArray(): void {
+    console.log(this.testResultHistory);
+    if (this.testResultHistory.length) {
+      this.testResultHistoryClone.forEach((testResult, testIndex) => {
+        if (
+          testResult.testTypes.length &&
+          testResult.testStatus === TEST_REPORT_STATUSES.SUBMITTED
+        ) {
+          testResult.testTypes.forEach((testType, typeTypeIndex) => {
+            testType.testIndex = testIndex;
+            testType.testTypeIndex = typeTypeIndex;
+            this.testTypeService.fixDateFormatting(testType);
+            this.testTypeArray.push(testType);
+          });
+        }
+      });
+      delete this.testResultHistoryClone;
+    }
+  }
+
+  haveProhibition(testType): boolean {
+    let resp = false;
+    if (testType.prohibitionIssued) {
+      resp = true;
+    } else {
+      if (testType.defects && testType.defects.length) {
+        testType.defects.forEach((defect) => {
+          if (defect.prohibitionIssued) { resp = true; }
+        });
+      } else {
+        resp = false;
+      }
+    }
+    return resp;
+  }
+
+  isVehicleOfType(vehicle: VehicleModel, ...vehicleType: VEHICLE_TYPE[]) {
+    return this.commonFunc.checkForMatchInArray(vehicle.techRecord.vehicleType, vehicleType);
+  }
+}

--- a/src/app/pages/vehicle/vehicle-history/vehicle-history.ts
+++ b/src/app/pages/vehicle/vehicle-history/vehicle-history.ts
@@ -64,7 +64,6 @@ export class VehicleHistoryPage implements OnInit {
   }
 
   createTestTypeArray(): void {
-    console.log(this.testResultHistory);
     if (this.testResultHistory.length) {
       this.testResultHistoryClone.forEach((testResult, testIndex) => {
         if (

--- a/src/app/pages/vehicle/vehicle-lookup/multiple-tech-records-selection/multiple-tech-records-selection.spec.ts
+++ b/src/app/pages/vehicle/vehicle-lookup/multiple-tech-records-selection/multiple-tech-records-selection.spec.ts
@@ -116,25 +116,4 @@ describe('Component: ', () => {
     });
   });
 
-  it('should open the vehicle details page if the call to test-results is failing', async () => {
-    spyOn(vehicleService, 'getTestResultsHistory').and.returnValue(throwError('error'));
-    spyOn(vehicleService, 'isVehicleSkeleton').and.returnValue(false);
-    await component.openVehicleDetails(VehicleDataMock.VehicleData);
-
-    expect(await analyticsService.logEvent).toHaveBeenCalledWith({
-      category: ANALYTICS_EVENT_CATEGORIES.ERRORS,
-      event: ANALYTICS_EVENTS.TEST_ERROR,
-      label: ANALYTICS_VALUE.TEST_RESULT_HISTORY_FAILED
-    });
-
-    expect(await navigateSpy).toHaveBeenCalledWith(
-      [PAGE_NAMES.VEHICLE_DETAILS_PAGE], {
-        state : {
-          test: undefined,
-          vehicle: VehicleDataMock.VehicleData,
-          previousPageName: PAGE_NAMES.MULTIPLE_TECH_RECORDS_SELECTION,
-          testStation: TEST_STATION
-        }
-      });
-  });
 });

--- a/src/app/pages/vehicle/vehicle-lookup/multiple-tech-records-selection/multiple-tech-records-selection.ts
+++ b/src/app/pages/vehicle/vehicle-lookup/multiple-tech-records-selection/multiple-tech-records-selection.ts
@@ -63,46 +63,13 @@ export class MultipleTechRecordsSelectionPage implements OnInit{
     });
     await LOADING.present();
 
-    const { oid } = this.authenticationService.tokenInfo;
-
-    const testHistoryResponseObserver: Observer<TestResultModel[]> = {
-      next: async () => {
-        await this.goToVehicleDetails(selectedVehicle);
-      },
-      error: async (error) => {
-        this.logProvider.dispatchLog({
-          type:
-            'error-vehicleService.getTestResultsHistory-openVehicleDetails in multiple-tech-records-selection.ts',
-          message: `${oid} - ${error.status} ${error.error} for API call to ${error.url}`,
-          timestamp: Date.now()
-        });
-
-        await this.trackErrorOnRetrieval(ANALYTICS_VALUE.TEST_RESULT_HISTORY_FAILED);
-        await this.storageService.update(STORAGE.TEST_HISTORY + selectedVehicle.systemNumber, []);
-        await this.goToVehicleDetails(selectedVehicle);
-      },
-      complete: () => {}
-    };
-
     if (this.vehicleService.isVehicleSkeleton(selectedVehicle)) {
       await LOADING.dismiss();
       await this.vehicleService.createSkeletonAlert(this.alertCtrl);
     } else {
-      this.vehicleService
-        .getTestResultsHistory(selectedVehicle.systemNumber)
-        .subscribe(testHistoryResponseObserver)
-        .add(() => {
-          LOADING.dismiss();
-        });
+      await this.goToVehicleDetails(selectedVehicle);
+      await LOADING.dismiss();
     }
-  }
-
-  private async trackErrorOnRetrieval(value: string) {
-    await this.analyticsService.logEvent({
-      category: ANALYTICS_EVENT_CATEGORIES.ERRORS,
-      event: ANALYTICS_EVENTS.TEST_ERROR,
-      label: value
-    });
   }
 
   async goToVehicleDetails(selectedVehicle: VehicleModel) {

--- a/src/app/pages/vehicle/vehicle-lookup/vehicle-lookup.spec.ts
+++ b/src/app/pages/vehicle/vehicle-lookup/vehicle-lookup.spec.ts
@@ -166,26 +166,6 @@ describe('Component: VehicleLookupPage', () => {
     expect(component.getTechRecordQueryParam().queryParam).toEqual('trailerId');
   });
 
-  it('should empty ionic storage if the test history cannot be retrieved', async () => {
-    spyOn(storageService, 'update');
-    component.loading = loadingCtrl.create({ message: '' });
-
-
-    vehicleService.getVehicleTechRecords = jasmine.createSpy().and.callFake(() => of([VEHICLE]));
-    vehicleService.getTestResultsHistory = jasmine
-      .createSpy()
-      .and.callFake(() => _throw('Error'));
-
-    await component.searchVehicle('TESTVIN', component.loading);
-
-    expect(await storageService.update).toHaveBeenCalledTimes(1);
-    expect(await analyticsService.logEvent).toHaveBeenCalledWith({
-      category: ANALYTICS_EVENT_CATEGORIES.ERRORS,
-      event: ANALYTICS_EVENTS.TEST_ERROR,
-      label: ANALYTICS_VALUE.TEST_RESULT_HISTORY_FAILED
-    });
-  });
-
   it('should dismiss the loading when the skeleton alert is displayed', async () => {
     const skeletonVehicle = JSON.parse(JSON.stringify(VEHICLE));
     component.loading = loadingCtrl.create({ message: '' });

--- a/src/app/pages/vehicle/vehicle-lookup/vehicle-lookup.ts
+++ b/src/app/pages/vehicle/vehicle-lookup/vehicle-lookup.ts
@@ -148,24 +148,6 @@ export class VehicleLookupPage implements OnInit {
       )
       .subscribe(
         (vehicleData) => {
-          const testHistoryResponseObserver: Observer<TestResultModel[]> = {
-            next: async () => {
-              await this.goToVehicleDetails(vehicleData[0]);
-            },
-            error: async (error) => {
-              this.logProvider.dispatchLog({
-                type:
-                  'error-vehicleService.getTestResultsHistory-searchVehicle in vehicle-lookup.ts',
-                message: `${oid} - ${error.status} ${error.error} for API call to ${error.url}`,
-                timestamp: Date.now()
-              });
-
-              await this.trackErrorOnSearchRecord(ANALYTICS_VALUE.TEST_RESULT_HISTORY_FAILED);
-              await this.storageService.update(STORAGE.TEST_HISTORY + vehicleData[0].systemNumber, []);
-              await this.goToVehicleDetails(vehicleData[0]);
-            },
-            complete: () => {}
-          };
           if (vehicleData.length > 1) {
             this.goToMultipleTechRecordsSelection(vehicleData).then(() => {
               LOADING.dismiss();
@@ -177,12 +159,8 @@ export class VehicleLookupPage implements OnInit {
             this.vehicleService.createSkeletonAlert(this.alertCtrl);
             LOADING.dismiss();
           } else {
-            this.vehicleService
-              .getTestResultsHistory(vehicleData[0].systemNumber)
-              .subscribe(testHistoryResponseObserver)
-              .add(() => {
-                LOADING.dismiss();
-              });
+            this.goToVehicleDetails(vehicleData[0]);
+            LOADING.dismiss();
           }
         },
         async (error) => {

--- a/src/app/pages/visit/visit-timeline/visit-timeline.spec.ts
+++ b/src/app/pages/visit/visit-timeline/visit-timeline.spec.ts
@@ -56,6 +56,7 @@ import { throwError } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { VisitServiceMock } from '@test-config/services-mocks/visit-service.mock';
 import { VehicleLookupPage } from '@app/pages/vehicle/vehicle-lookup/vehicle-lookup';
+import { VisitConfirmationPage } from '@app/pages/visit/visit-confirmation/visit-confirmation';
 
 describe('Component: VisitTimelinePage', () => {
   let component: VisitTimelinePage;
@@ -133,6 +134,10 @@ describe('Component: VisitTimelinePage', () => {
           {
             path: PAGE_NAMES.VEHICLE_LOOKUP_PAGE,
             component: VehicleLookupPage
+          },
+          {
+            path: PAGE_NAMES.VISIT_CONFIRMATION_PAGE,
+            component: VisitConfirmationPage
           }
         ]),
       ],
@@ -265,14 +270,14 @@ describe('Component: VisitTimelinePage', () => {
 
       expect(sitePrevClosed).toBeUndefined();
       expect(component.isCreateTestEnabled).toBeFalsy();
-      expect(component.showLoading).toHaveBeenCalledWith(APP_STRINGS.END_VISIT_LOADING);
-      expect(visitService.endVisit).toHaveBeenCalledWith(getMockVisit().id);
-      expect(analyticsService.logEvent).toHaveBeenCalledWith({
+      expect(await component.showLoading).toHaveBeenCalledWith(APP_STRINGS.END_VISIT_LOADING);
+      expect(await visitService.endVisit).toHaveBeenCalledWith(getMockVisit().id);
+      expect(await analyticsService.logEvent).toHaveBeenCalledWith({
         category: ANALYTICS_EVENT_CATEGORIES.VISIT,
         event: ANALYTICS_EVENTS.SUBMIT_VISIT
       });
       expect(logProvider.dispatchLog).toHaveBeenCalled();
-      expect(alertCtrl.create).toHaveBeenCalled();
+      expect(await alertCtrl.create).toHaveBeenCalled();
     });
 
     it('should display the try again alert on internet required error', async () => {

--- a/src/app/providers/vehicle/vehicle.service.spec.ts
+++ b/src/app/providers/vehicle/vehicle.service.spec.ts
@@ -185,18 +185,6 @@ describe('Provider: VehicleService', () => {
     expect(onlyOne).toBeTruthy();
   });
 
-  it('should update ionic storage when retrieving test results history', waitForAsync(() => {
-    const systemNumber = '10000000';
-    spyOn(storageService, 'update');
-    vehicleService.getTestResultsHistory(systemNumber).subscribe(() => {
-      expect(storageService.update).toHaveBeenCalledTimes(1);
-      expect(storageService.update).toHaveBeenCalledWith(
-        STORAGE.TEST_HISTORY + systemNumber,
-        TestResultsHistoryDataMock.TestResultHistoryData
-      );
-    });
-  }));
-
   it('should check if a specific vehicle is a skeleton record or not', () => {
     const testVehicle = { ...VehicleDataMock.VehicleData };
     expect(vehicleService.isVehicleSkeleton(testVehicle)).toBeFalsy();

--- a/src/app/providers/vehicle/vehicle.service.ts
+++ b/src/app/providers/vehicle/vehicle.service.ts
@@ -97,7 +97,7 @@ export class VehicleService {
             timestamp: Date.now()
           });
 
-          this.storageService.update(STORAGE.TEST_HISTORY + systemNumber, data.body);
+          // this.storageService.update(STORAGE.TEST_HISTORY + systemNumber, data.body);
           return data.body;
         })
       );

--- a/src/app/providers/vehicle/vehicle.service.ts
+++ b/src/app/providers/vehicle/vehicle.service.ts
@@ -9,7 +9,7 @@ import { TestTypeModel } from '@models/tests/test-type.model';
 import { VehicleTechRecordModel } from '@models/vehicle/tech-record.model';
 import { PreparersReferenceDataModel } from '@models/reference-data-models/preparers.model';
 import { CountryOfRegistrationData } from '@assets/app-data/country-of-registration/country-of-registration.data';
-import { APP_STRINGS, STORAGE, TEST_TYPE_INPUTS } from '@app/app.enums';
+import { APP_STRINGS, TEST_TYPE_INPUTS } from '@app/app.enums';
 import { HttpResponse } from '@angular/common/http';
 import { TestResultModel } from '@models/tests/test-result.model';
 import { StorageService } from '../natives/storage.service';

--- a/src/app/providers/vehicle/vehicle.service.ts
+++ b/src/app/providers/vehicle/vehicle.service.ts
@@ -97,7 +97,6 @@ export class VehicleService {
             timestamp: Date.now()
           });
 
-          // this.storageService.update(STORAGE.TEST_HISTORY + systemNumber, data.body);
           return data.body;
         })
       );


### PR DESCRIPTION
Introduces the vehicle history page to the application

Also moves the http call from the vehicle lookup page to when someone clicks the goToVehicleHistory button, this is a small change that was agreed so that we would not need to make it further along the line when VTA-461 gets moved over to Ionic 5, this meant that the Storage related code was now redundant as it was only storing the data for the pages in between the vehicle lookup and the vehicle test history page itself

<img width="447" alt="image" src="https://user-images.githubusercontent.com/28736958/168099213-af02d691-188b-462f-b7a9-06e6513bba6f.png">
<img width="442" alt="image" src="https://user-images.githubusercontent.com/28736958/168099477-e93e780a-bc74-4b11-8dac-789ec5d41f81.png">
